### PR TITLE
Fix doc terminology to use Room

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -56,39 +56,39 @@ WezTermマルチプロセス開発補助ツールのAPI仕様を定義します�
 ```json
 {
   "Status": {
-    "workspaces": [...],
+    "rooms": [...],
     "processes": [...],
     "system_metrics": {...}
   }
 }
 ```
 
-### 2.2 ワークスペース管理
+### 2.2 Room管理
 
-#### WorkspaceCreate
+#### RoomCreate
 ```json
 {
-  "WorkspaceCreate": {
+  "RoomCreate": {
     "name": "project-name",
     "template": "default|web_dev|rust_dev|research"
   }
 }
 ```
 
-#### WorkspaceSwitch
+#### RoomSwitch
 ```json
 {
-  "WorkspaceSwitch": {
-    "name": "workspace-name"
+  "RoomSwitch": {
+    "name": "room-name"
   }
 }
 ```
 
-#### WorkspaceDelete
+#### RoomDelete
 ```json
 {
-  "WorkspaceDelete": {
-    "name": "workspace-name"
+  "RoomDelete": {
+    "name": "room-name"
   }
 }
 ```
@@ -101,8 +101,8 @@ WezTermマルチプロセス開発補助ツールのAPI仕様を定義します�
   "ProcessSpawn": {
     "id": "process-id",
     "command": "claude-code",
-    "args": ["--workspace", "main"],
-    "workspace": "workspace-name",
+    "args": ["--room", "main"],
+    "room": "room-name",
     "env": {
       "CLAUDE_SESSION": "session-id"
     }
@@ -204,20 +204,20 @@ WezTermマルチプロセス開発補助ツールのAPI仕様を定義します�
 
 ## 4. Lua API (WezTerm統合)
 
-### 4.1 ワークスペース操作
+### 4.1 Room操作
 
 ```lua
--- ワークスペース作成
-wezterm_parallel.create_workspace({
+-- Room作成
+wezterm_parallel.create_room({
   name = "my-project",
   template = "claude-dev"
 })
 
--- ワークスペース切り替え
-wezterm_parallel.switch_workspace("my-project")
+-- Room切り替え
+wezterm_parallel.switch_room("my-project")
 
--- ワークスペース一覧
-local workspaces = wezterm_parallel.list_workspaces()
+-- Room一覧
+local rooms = wezterm_parallel.list_rooms()
 ```
 
 ### 4.2 テンプレート適用 (Issue #18)
@@ -242,7 +242,7 @@ wezterm_parallel.save_current_layout({
 wezterm_parallel.spawn_process({
   id = "claude-main",
   command = "claude-code",
-  workspace = "current"
+  room = "current"
 })
 
 -- プロセス状態取得
@@ -253,8 +253,8 @@ local status = wezterm_parallel.get_process_status("claude-main")
 
 | コード | 説明 |
 |-------|------|
-| 1001 | ワークスペースが見つからない |
-| 1002 | ワークスペース作成失敗 |
+| 1001 | Roomが見つからない |
+| 1002 | Room作成失敗 |
 | 2001 | プロセスが見つからない |
 | 2002 | プロセス起動失敗 |
 | 3001 | タスクが見つからない |

--- a/docs/DATA-FLOW.md
+++ b/docs/DATA-FLOW.md
@@ -128,11 +128,11 @@ graph TB
 
 ## 5. 状態管理フロー
 
-### 5.1 ワークスペース状態
+### 5.1 Room状態
 
 ```yaml
-# ~/.wezterm-parallel/workspaces/project-name/state.yaml
-workspace:
+# ~/.wezterm-parallel/rooms/project-name/state.yaml
+room:
   name: project-name
   created_at: 2025-06-27T10:00:00Z
   template: claude-dev
@@ -198,7 +198,7 @@ tasks:
 2. Unix Socket → ファイル権限チェック
 3. SessionManager → セッション作成
 4. 全リクエスト → セッション検証
-5. プロセス → ワークスペース境界内で動作
+5. プロセス → Room境界内で動作
 ```
 
 ### 7.2 ログ記録

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -76,11 +76,11 @@ server:
   websocket_port: 9999
   log_level: info
 
-# ワークスペース設定
-workspace:
-  max_workspaces: 8
+# Room設定
+room:
+  max_rooms: 8
   default_template: claude-dev
-  state_dir: ~/.wezterm-parallel/workspaces
+  state_dir: ~/.wezterm-parallel/rooms
 
 # プロセス設定
 process:
@@ -110,9 +110,9 @@ wezterm_parallel.setup({
 
 -- キーバインド追加
 config.keys = {
-  -- ワークスペース操作
-  { key = 'n', mods = 'CTRL|SHIFT', action = wezterm_parallel.create_workspace },
-  { key = 'w', mods = 'CTRL|SHIFT', action = wezterm_parallel.switch_workspace },
+  -- Room操作
+  { key = 'n', mods = 'CTRL|SHIFT', action = wezterm_parallel.create_room },
+  { key = 'w', mods = 'CTRL|SHIFT', action = wezterm_parallel.switch_room },
   
   -- テンプレート操作 (Issue #18)
   { key = 't', mods = 'ALT', action = wezterm_parallel.show_template_picker },
@@ -158,9 +158,9 @@ sudo systemctl stop wezterm-parallel
 # 1. WezTermを起動
 wezterm
 
-# 2. 新規ワークスペース作成（Ctrl+Shift+N）
+# 2. 新規Room作成（Ctrl+Shift+N）
 # または
-echo '{"WorkspaceCreate":{"name":"my-project","template":"claude-dev"}}' | nc -U /tmp/wezterm-parallel.sock
+echo '{"RoomCreate":{"name":"my-project","template":"claude-dev"}}' | nc -U /tmp/wezterm-parallel.sock
 
 # 3. テンプレート適用（Alt+T）
 # 自動的にペインが分割され、Claude Codeが起動

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -126,7 +126,7 @@ impl Message {
 
 #### テンプレート検証
 ```lua
--- lua/workspace/template_validator.lua
+-- lua/room/template_validator.lua
 local validator = {}
 
 function validator.validate_template(template)
@@ -375,7 +375,7 @@ mod security_tests {
         ];
         
         for path in paths {
-            let result = validate_workspace_path(path);
+            let result = validate_room_path(path);
             assert!(result.is_err());
         }
     }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -62,18 +62,18 @@ mod tests {
 ```rust
 // tests/integration_test.rs
 #[tokio::test]
-async fn test_workspace_process_integration() {
-    let workspace_manager = WorkspaceManager::new();
+async fn test_room_process_integration() {
+    let room_manager = RoomManager::new();
     let process_manager = ProcessManager::new();
     
-    // ワークスペース作成
-    workspace_manager.create("test-workspace", "default").await.unwrap();
+    // Room作成
+    room_manager.create("test-room", "default").await.unwrap();
     
     // プロセス起動
     let process_id = process_manager.spawn_process(
         "test-process",
         "claude-code",
-        Some("test-workspace")
+        Some("test-room")
     ).await.unwrap();
     
     // 統合動作確認
@@ -180,9 +180,9 @@ fn test_with_mock() {
 
 ```rust
 // tests/fixtures/mod.rs
-pub fn create_test_workspace() -> Workspace {
-    Workspace {
-        name: "test-workspace".to_string(),
+pub fn create_test_room() -> Room {
+    Room {
+        name: "test-room".to_string(),
         template: "default".to_string(),
         created_at: 0,
     }


### PR DESCRIPTION
## Summary
- update API docs with Room terminology
- rename workspace references in data flow diagrams
- adjust deployment documentation for Room
- apply term changes in security and testing docs

## Testing
- `cargo test --quiet` *(fails: could not compile `wezterm-parallel`)*

------
https://chatgpt.com/codex/tasks/task_b_6865f0072a60832f903150a009f72bbf